### PR TITLE
update to alpine linux 3.17.2 & mariadb 10.6.12 [Duplicated]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,20 +107,20 @@ amd64 mariadb version build:
   - apk add --update git
   - echo "$CI_JOB_TOKEN" | docker login -u gitlab-ci-token "$DOCKER_REGISTRY" --password-stdin
   - cd alpine-mariadb-amd64/ && docker build --build-arg VCS_REF=${CI_COMMIT_SHORT_SHA}
-    --build-arg BUILD_DATE=${COMMIT_TIME} -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
-    -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-x86_64 -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
-    -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-x86_64 -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-amd64
-    -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-x86_64 .
-  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
-  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-x86_64
+    --build-arg BUILD_DATE=${COMMIT_TIME} -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
+    -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-x86_64 -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
+    -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-x86_64 -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-amd64
+    -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-x86_64 .
+  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
+  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-x86_64
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
+    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-x86_64
+    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-x86_64
   - echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USERNAME" quay.io --password-stdin
-    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-amd64
+    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-amd64
   - echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USERNAME" quay.io --password-stdin
-    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-x86_64
+    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-x86_64
 arm32v7 mariadb version build:
   image: yobasystems/alpine-docker:dind
   stage: build
@@ -135,20 +135,20 @@ arm32v7 mariadb version build:
   - apk add --update git
   - echo "$CI_JOB_TOKEN" | docker login -u gitlab-ci-token "$DOCKER_REGISTRY" --password-stdin
   - cd alpine-mariadb-armhf/ && docker build --build-arg VCS_REF=${CI_COMMIT_SHORT_SHA}
-    --build-arg BUILD_DATE=${COMMIT_TIME} -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7
-    -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7 -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-arm32v7
-    -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-armhf -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-armhf
-    -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-armhf .
-  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7
-  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-armhf
+    --build-arg BUILD_DATE=${COMMIT_TIME} -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7
+    -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7 -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-arm32v7
+    -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-armhf -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-armhf
+    -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-armhf .
+  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7
+  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-armhf
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7
+    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-armhf
+    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-armhf
   - echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USERNAME" quay.io --password-stdin
-    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-arm32v7
+    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-arm32v7
   - echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USERNAME" quay.io --password-stdin
-    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-armhf
+    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-armhf
 arm64v8 mariadb version build:
   image: yobasystems/alpine-docker:dind
   stage: build
@@ -163,20 +163,20 @@ arm64v8 mariadb version build:
   - apk add --update git
   - echo "$CI_JOB_TOKEN" | docker login -u gitlab-ci-token "$DOCKER_REGISTRY" --password-stdin
   - cd alpine-mariadb-aarch64/ && docker build --build-arg VCS_REF=${CI_COMMIT_SHORT_SHA}
-    --build-arg BUILD_DATE=${COMMIT_TIME} -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
-    -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8 -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-arm64v8
-    -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-aarch64 -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-aarch64
-    -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-aarch64 .
-  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
-  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-aarch64
+    --build-arg BUILD_DATE=${COMMIT_TIME} -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
+    -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8 -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-arm64v8
+    -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-aarch64 -t $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-aarch64
+    -t $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-aarch64 .
+  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
+  - docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-aarch64
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
+    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-aarch64
+    && docker push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-aarch64
   - echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USERNAME" quay.io --password-stdin
-    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-arm64v8
+    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-arm64v8
   - echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USERNAME" quay.io --password-stdin
-    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.11-aarch64
+    && docker push $DOCKER_REGISTRY_QUAY/$DOCKER_REGISTRY_QUAY_REPO:10.6.12-aarch64
 gitlab latest manifest creation:
   image: yobasystems/alpine-docker:dind
   stage: manifest
@@ -219,7 +219,7 @@ dockerhub latest manifest creation:
   - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:latest $DOCKER_REGISTRY_DOCKERHUB_REPO:arm64v8
     --os linux --arch arm64
   - docker manifest push $DOCKER_REGISTRY_DOCKERHUB_REPO:latest
-gitlab version 10.6.11 manifest creation:
+gitlab version 10.6.12 manifest creation:
   image: yobasystems/alpine-docker:dind
   stage: manifest
   tags:
@@ -228,19 +228,19 @@ gitlab version 10.6.11 manifest creation:
   - mkdir /root/.docker
   - 'echo -e "{\n    \"experimental\": \"enabled\"\n}\n" >> ~/.docker/config.json'
   - echo "$CI_JOB_TOKEN" | docker login -u gitlab-ci-token "$DOCKER_REGISTRY" --password-stdin
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
-  - docker manifest create $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
-    $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
+  - docker manifest create $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
+    $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
     --os linux --arch amd64
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7
     --os linux --arch arm
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
     --os linux --arch arm64
-  - docker manifest push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11
-dockerhub version 10.6.11 manifest creation:
+  - docker manifest push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12
+dockerhub version 10.6.12 manifest creation:
   image: yobasystems/alpine-docker:dind
   stage: manifest
   tags:
@@ -249,18 +249,18 @@ dockerhub version 10.6.11 manifest creation:
   - mkdir /root/.docker
   - 'echo -e "{\n    \"experimental\": \"enabled\"\n}\n" >> ~/.docker/config.json'
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
-  - docker manifest create $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
-    $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
+  - docker manifest create $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
+    $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
     --os linux --arch amd64
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7
     --os linux --arch arm
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
     --os linux --arch arm64
-  - docker manifest push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11
+  - docker manifest push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12
 gitlab minor version 10.6 manifest creation:
   image: yobasystems/alpine-docker:dind
   stage: manifest
@@ -270,16 +270,16 @@ gitlab minor version 10.6 manifest creation:
   - mkdir /root/.docker
   - 'echo -e "{\n    \"experimental\": \"enabled\"\n}\n" >> ~/.docker/config.json'
   - echo "$CI_JOB_TOKEN" | docker login -u gitlab-ci-token "$DOCKER_REGISTRY" --password-stdin
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
-  - docker manifest create $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
-    $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
+  - docker manifest create $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
+    $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
     --os linux --arch amd64
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7
     --os linux --arch arm
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
     --os linux --arch arm64
   - docker manifest push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6
 dockerhub minor version 10.6 manifest creation:
@@ -291,16 +291,16 @@ dockerhub minor version 10.6 manifest creation:
   - mkdir /root/.docker
   - 'echo -e "{\n    \"experimental\": \"enabled\"\n}\n" >> ~/.docker/config.json'
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
-  - docker manifest create $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
-    $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
+  - docker manifest create $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
+    $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
     --os linux --arch amd64
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7
     --os linux --arch arm
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
     --os linux --arch arm64
   - docker manifest push $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6
 gitlab major version 10 manifest creation:
@@ -312,16 +312,16 @@ gitlab major version 10 manifest creation:
   - mkdir /root/.docker
   - 'echo -e "{\n    \"experimental\": \"enabled\"\n}\n" >> ~/.docker/config.json'
   - echo "$CI_JOB_TOKEN" | docker login -u gitlab-ci-token "$DOCKER_REGISTRY" --password-stdin
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7
-  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
-  - docker manifest create $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
-    $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-amd64
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7
+  - docker pull $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
+  - docker manifest create $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
+    $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-amd64
     --os linux --arch amd64
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm32v7
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm32v7
     --os linux --arch arm
-  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.11-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10 $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10.6.12-arm64v8
     --os linux --arch arm64
   - docker manifest push $DOCKER_REGISTRY/$DOCKER_REGISTRY_REPO:10
 dockerhub major version 10 manifest creation:
@@ -333,16 +333,16 @@ dockerhub major version 10 manifest creation:
   - mkdir /root/.docker
   - 'echo -e "{\n    \"experimental\": \"enabled\"\n}\n" >> ~/.docker/config.json'
   - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7
-  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
-  - docker manifest create $DOCKER_REGISTRY_DOCKERHUB_REPO:10 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
-    $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-amd64
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7
+  - docker pull $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
+  - docker manifest create $DOCKER_REGISTRY_DOCKERHUB_REPO:10 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
+    $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-amd64
     --os linux --arch amd64
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm32v7
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm32v7
     --os linux --arch arm
-  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.11-arm64v8
+  - docker manifest annotate $DOCKER_REGISTRY_DOCKERHUB_REPO:10 $DOCKER_REGISTRY_DOCKERHUB_REPO:10.6.12-arm64v8
     --os linux --arch arm64
   - docker manifest push $DOCKER_REGISTRY_DOCKERHUB_REPO:10
 sast:

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![Docker Pulls](https://img.shields.io/docker/pulls/yobasystems/alpine-mariadb.svg?style=for-the-badge&logo=docker)](https://hub.docker.com/r/yobasystems/alpine-mariadb/)
 [![Docker Stars](https://img.shields.io/docker/stars/yobasystems/alpine-mariadb.svg?style=for-the-badge&logo=docker)](https://hub.docker.com/r/yobasystems/alpine-mariadb/)
 
-[![Alpine Version](https://img.shields.io/badge/Alpine%20version-v3.17.0-green.svg?style=for-the-badge&logo=alpine-linux)](https://alpinelinux.org/)
-[![MariaDB Version](https://img.shields.io/badge/Mariadb%20version-v10.6.11-green.svg?style=for-the-badge&logo=mariadb)](https://mariadb.org/)
+[![Alpine Version](https://img.shields.io/badge/Alpine%20version-v3.17.2-green.svg?style=for-the-badge&logo=alpine-linux)](https://alpinelinux.org/)
+[![MariaDB Version](https://img.shields.io/badge/Mariadb%20version-v10.6.12-green.svg?style=for-the-badge&logo=mariadb)](https://mariadb.org/)
 
 
-This Docker image [(yobasystems/alpine-mariadb)](https://hub.docker.com/r/yobasystems/alpine-mariadb/) is based on the minimal [Alpine Linux](https://alpinelinux.org/) with [MariaDB v10.6.11](https://mariadb.org/) (MySQL Compatible) database server.
+This Docker image [(yobasystems/alpine-mariadb)](https://hub.docker.com/r/yobasystems/alpine-mariadb/) is based on the minimal [Alpine Linux](https://alpinelinux.org/) with [MariaDB v10.6.12](https://mariadb.org/) (MySQL Compatible) database server.
 
-### Alpine Version 3.17.0 (Released 2022-11-22)
-##### MariaDB Version 10.6.11
+### Alpine Version 3.17.2 (Released 2023-02-10)
+##### MariaDB Version 10.6.12 (Released 2023-02-07)
 
 ----
 
@@ -47,7 +47,7 @@ MariaDB is developed as open source software and as a relational database it pro
 * ```:amd64```, ```:x86_64```  amd64 based on latest tag but amd64 architecture
 * ```:aarch64```, ```:arm64v8``` Armv8 based on latest tag but arm64 architecture
 * ```:armhf```, ```:arm32v7``` Armv7 based on latest tag but arm32 architecture
-* ```:version``` Version tags e.g ```:10```, ```:10.6```, ```10.6.11```
+* ```:version``` Version tags e.g ```:10```, ```:10.6```, ```10.6.12```
 
 ## Layers & Sizes
 

--- a/alpine-mariadb-aarch64/Dockerfile
+++ b/alpine-mariadb-aarch64/Dockerfile
@@ -1,18 +1,18 @@
-FROM yobasystems/alpine:3.17.0-aarch64
+FROM yobasystems/alpine:3.17.2-aarch64
 
 ARG BUILD_DATE
 ARG VCS_REF
 
 LABEL maintainer="Dominic Taylor <dominic@yobasystems.co.uk>" \
     architecture="arm64v8/aarch64" \
-    mariadb-version="10.6.11" \
-    alpine-version="3.17.0" \
+    mariadb-version="10.6.12" \
+    alpine-version="3.17.2" \
     build="06-Dec-2022" \
     org.opencontainers.image.title="alpine-mariadb" \
     org.opencontainers.image.description="MariaDB Docker image running on Alpine Linux" \
     org.opencontainers.image.authors="Dominic Taylor <dominic@yobasystems.co.uk>" \
     org.opencontainers.image.vendor="Yoba Systems" \
-    org.opencontainers.image.version="v10.6.11" \
+    org.opencontainers.image.version="v10.6.12" \
     org.opencontainers.image.url="https://hub.docker.com/r/yobasystems/alpine-mariadb/" \
     org.opencontainers.image.source="https://github.com/yobasystems/alpine-mariadb" \
     org.opencontainers.image.revision=$VCS_REF \

--- a/alpine-mariadb-amd64/Dockerfile
+++ b/alpine-mariadb-amd64/Dockerfile
@@ -1,18 +1,18 @@
-FROM yobasystems/alpine:3.17.0-amd64
+FROM yobasystems/alpine:3.17.2-amd64
 
 ARG BUILD_DATE
 ARG VCS_REF
 
 LABEL maintainer="Dominic Taylor <dominic@yobasystems.co.uk>" \
     architecture="amd64/x86_64" \
-    mariadb-version="10.6.11" \
-    alpine-version="3.17.0" \
+    mariadb-version="10.6.12" \
+    alpine-version="3.17.2" \
     build="06-Dec-2022" \
     org.opencontainers.image.title="alpine-mariadb" \
     org.opencontainers.image.description="MariaDB Docker image running on Alpine Linux" \
     org.opencontainers.image.authors="Dominic Taylor <dominic@yobasystems.co.uk>" \
     org.opencontainers.image.vendor="Yoba Systems" \
-    org.opencontainers.image.version="v10.6.11" \
+    org.opencontainers.image.version="v10.6.12" \
     org.opencontainers.image.url="https://hub.docker.com/r/yobasystems/alpine-mariadb/" \
     org.opencontainers.image.source="https://github.com/yobasystems/alpine-mariadb" \
     org.opencontainers.image.revision=$VCS_REF \

--- a/alpine-mariadb-armhf/Dockerfile
+++ b/alpine-mariadb-armhf/Dockerfile
@@ -1,18 +1,18 @@
-FROM yobasystems/alpine:3.17.0-armhf
+FROM yobasystems/alpine:3.17.2-armhf
 
 ARG BUILD_DATE
 ARG VCS_REF
 
 LABEL maintainer="Dominic Taylor <dominic@yobasystems.co.uk>" \
     architecture="arm32v7/armhf" \
-    mariadb-version="10.6.11" \
-    alpine-version="3.17.0" \
+    mariadb-version="10.6.12" \
+    alpine-version="3.17.2" \
     build="06-Dec-2022" \
     org.opencontainers.image.title="alpine-mariadb" \
     org.opencontainers.image.description="MariaDB Docker image running on Alpine Linux" \
     org.opencontainers.image.authors="Dominic Taylor <dominic@yobasystems.co.uk>" \
     org.opencontainers.image.vendor="Yoba Systems" \
-    org.opencontainers.image.version="v10.6.11" \
+    org.opencontainers.image.version="v10.6.12" \
     org.opencontainers.image.url="https://hub.docker.com/r/yobasystems/alpine-mariadb/" \
     org.opencontainers.image.source="https://github.com/yobasystems/alpine-mariadb" \
     org.opencontainers.image.revision=$VCS_REF \


### PR DESCRIPTION
## Mariadb 10.6.12 changes : 
- Includes fixes for  pam module dir

## Alpine linux 3.17.2 changes :  
- This release includes various security fixes, including:
    - openssl [CVE-2023-0286](https://security.alpinelinux.org/vuln/CVE-2023-0286)
    - openssl [CVE-2022-4304](https://security.alpinelinux.org/vuln/CVE-2022-4304)
- The full lists of changes can be found in the [git log](http://git.alpinelinux.org/aports/log/?h=v3.17.2).